### PR TITLE
Initial Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /tmp
 /coverage
 Gemfile.lock
+/pkg
+/spec/config/database.yaml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Metrics/MethodLength:
     - spec/db_helper.rb
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
 
 Metrics/AbcSize:
   Max: 16

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Metrics/MethodLength:
     - spec/db_helper.rb
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Metrics/AbcSize:
   Max: 16

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,12 +12,16 @@ Metrics/BlockLength:
 
 Metrics/MethodLength:
   Max: 25
+  Exclude:
+    - spec/db_helper.rb
 
 AllCops:
   TargetRubyVersion: 2.3
 
 Metrics/AbcSize:
   Max: 16
+  Exclude:
+    - spec/db_helper.rb
 
 Metrics/ClassLength:
   Max: 125

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - mysql
 rvm:
   # Build on the latest stable of all supported Rubies (https://www.ruby-lang.org/en/downloads/):
-  - 2.5.3
-  - 2.6.0
+  - 2.4.6
+  - 2.5.5
   - 2.6.3
 cache: bundler
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ services:
   - mysql
 rvm:
   # Build on the latest stable of all supported Rubies (https://www.ruby-lang.org/en/downloads/):
-  - 2.3.8
-  - 2.4.5
   - 2.5.3
   - 2.6.0
   - 2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ env:
   global:
     - CC_TEST_REPORTER_ID=036a8fd92cf0c323c9704c041015837d14889e47de936bab18287626ff3372c1
 language: ruby
+services:
+  - mysql
 rvm:
   # Build on the latest stable of all supported Rubies (https://www.ruby-lang.org/en/downloads/):
   - 2.3.8
@@ -14,6 +16,8 @@ before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+  - cp spec/config/database.yaml.ci spec/config/database.yaml
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS dbee_test;'
 script:
   - bundle exec rubocop
   - bundle exec rspec spec --format documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0 (August 23rd, 2019)
+
+Initial release, stable public API.
+
 # 1.0.0-alpha (August 20th, 2019)
 
 Added initial implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0-alpha (August 20th, 2019)
+
+Added initial implementation.
+
 # 0.0.1 (August 18th, 2019)
 
 Initial library shell published.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at oss@bluemarblepayroll.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,75 @@
 # Dbee Active Record Provider
 
-Under Construction.
+[![Gem Version](https://badge.fury.io/rb/dbee-active_record.svg)](https://badge.fury.io/rb/dbee-active_record) [![Build Status](https://travis-ci.org/bluemarblepayroll/dbee-active_record.svg?branch=master)](https://travis-ci.org/bluemarblepayroll/dbee-active_record) [![Maintainability](https://api.codeclimate.com/v1/badges/7f74a4e546bebb603cce/maintainability)](https://codeclimate.com/github/bluemarblepayroll/dbee-active_record/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/7f74a4e546bebb603cce/test_coverage)](https://codeclimate.com/github/bluemarblepayroll/dbee-active_record/test_coverage) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Dbee does not ship with a SQL generator by default.  This library plugs into Dbee to provide SQL generation via ActiveRecord.  Technically speaking: this library does not use ActiveRecord for anything except connection information.  All actual SQL generation is performed using Arel.  There is no actual coupling of your domain ActiveRecord subclasses to Dbee.
+
+This library is a plugin for [Dbee](https://github.com/bluemarblepayroll/dbee).  The Dbee repositories README file contains information about how to use the Data Model and Query API's.
+
+## Installation
+
+To install through Rubygems:
+
+````
+gem install install dbee-active_record
+````
+
+You can also add this to your Gemfile:
+
+````
+bundle add dbee-active_record
+````
+
+## Contributing
+
+### Development Environment Configuration
+
+Basic steps to take to get this repository compiling:
+
+1. Install [Ruby](https://www.ruby-lang.org/en/documentation/installation/) (check dbee-active_record.gemspec for versions supported)
+2. Install bundler (gem install bundler)
+3. Clone the repository (git clone git@github.com:bluemarblepayroll/dbee-active_record.git)
+4. Navigate to the root folder (cd dbee-active_record)
+5. Install dependencies (bundle)
+6. Copy spec/config/database.yaml.ci to spec/config/database.yaml. Customize both sqlite and mysql connections per your local environment.
+
+### Running Tests
+
+To execute the test suite run:
+
+````bash
+bundle exec rspec spec --format documentation
+````
+
+Alternatively, you can have Guard watch for changes:
+
+````bash
+bundle exec guard
+````
+
+Also, do not forget to run Rubocop:
+
+````bash
+bundle exec rubocop
+````
+
+### Publishing
+
+Note: ensure you have proper authorization before trying to publish new versions.
+
+After code changes have successfully gone through the Pull Request review process then the following steps should be followed for publishing new versions:
+
+1. Merge Pull Request into master
+2. Update `lib/dbee-active_record/version.rb` using [semantic versioning](https://semver.org/)
+3. Install dependencies: `bundle`
+4. Update `CHANGELOG.md` with release notes
+5. Commit & push master to remote and ensure CI builds master successfully
+6. Run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Code of Conduct
+
+Everyone interacting in this codebase, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/bluemarblepayroll/dbee-active_record/blob/master/CODE_OF_CONDUCT.md).
+
+## License
+
+This project is MIT Licensed.

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,9 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
 
-task default: :spec
+task default: %i[rubocop spec]

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/dbee-active_record.gemspec
+++ b/dbee-active_record.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('guard-rspec', '~>4.7')
   s.add_development_dependency('mysql2', '~>0.5')
   s.add_development_dependency('pry', '~>0')
+  s.add_development_dependency('rake', '~> 12')
   s.add_development_dependency('rspec', '~> 3.8')
   s.add_development_dependency('rubocop', '~>0.63.1')
   s.add_development_dependency('simplecov', '~>0.16.1')

--- a/dbee-active_record.gemspec
+++ b/dbee-active_record.gemspec
@@ -19,18 +19,18 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/bluemarblepayroll/dbee-active_record'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.5.3'
+  s.required_ruby_version = '>= 2.4.6'
 
   s.add_dependency('activerecord', '~>5', '>=5.2.1')
-  s.add_dependency('dbee', '>=1.0.0.pre.alpha.2')
+  s.add_dependency('dbee', '~>1')
 
   s.add_development_dependency('guard-rspec', '~>4.7')
   s.add_development_dependency('mysql2', '~>0.5')
   s.add_development_dependency('pry', '~>0')
   s.add_development_dependency('rake', '~> 12')
   s.add_development_dependency('rspec', '~> 3.8')
-  s.add_development_dependency('rubocop', '~>0.63.1')
-  s.add_development_dependency('simplecov', '~>0.16.1')
-  s.add_development_dependency('simplecov-console', '~>0.4.2')
+  s.add_development_dependency('rubocop', '~>0.74.0')
+  s.add_development_dependency('simplecov', '~>0.17.0')
+  s.add_development_dependency('simplecov-console', '~>0.5.0')
   s.add_development_dependency('sqlite3', '~>1')
 end

--- a/dbee-active_record.gemspec
+++ b/dbee-active_record.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/bluemarblepayroll/dbee-active_record'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.3.8'
+  s.required_ruby_version = '>= 2.5.3'
 
   s.add_dependency('activerecord', '~>5', '>=5.2.1')
-  s.add_dependency('dbee', '>=1.0.0.pre.alpha.1')
+  s.add_dependency('dbee', '>=1.0.0.pre.alpha.2')
 
   s.add_development_dependency('guard-rspec', '~>4.7')
   s.add_development_dependency('mysql2', '~>0.5')

--- a/dbee-active_record.gemspec
+++ b/dbee-active_record.gemspec
@@ -3,7 +3,7 @@
 require './lib/dbee/providers/active_record_provider/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'dbee'
+  s.name        = 'dbee-active_record'
   s.version     = Dbee::Providers::ActiveRecordProvider::VERSION
   s.summary     = 'Plugs in ActiveRecord so Dbee can use Arel for SQL generation.'
 
@@ -21,10 +21,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.8'
 
+  s.add_dependency('activerecord', '~>5', '>=5.2.1')
+  s.add_dependency('dbee', '>=1.0.0.pre.alpha.1')
+
   s.add_development_dependency('guard-rspec', '~>4.7')
+  s.add_development_dependency('mysql2', '~>0.5')
   s.add_development_dependency('pry', '~>0')
   s.add_development_dependency('rspec', '~> 3.8')
   s.add_development_dependency('rubocop', '~>0.63.1')
   s.add_development_dependency('simplecov', '~>0.16.1')
   s.add_development_dependency('simplecov-console', '~>0.4.2')
+  s.add_development_dependency('sqlite3', '~>1')
 end

--- a/lib/dbee/providers/active_record_provider.rb
+++ b/lib/dbee/providers/active_record_provider.rb
@@ -21,6 +21,8 @@ module Dbee
       DEFAULT_TABLE_PREFIX  = 't'
       DEFAULT_COLUMN_PREFIX = 'c'
 
+      private_constant :DEFAULT_TABLE_PREFIX, :DEFAULT_COLUMN_PREFIX
+
       attr_reader :readable, :table_alias_maker, :column_alias_maker
 
       def initialize(

--- a/lib/dbee/providers/active_record_provider.rb
+++ b/lib/dbee/providers/active_record_provider.rb
@@ -6,3 +6,46 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 #
+
+require 'dbee'
+require 'active_record'
+
+require_relative 'active_record_provider/expression_builder'
+require_relative 'active_record_provider/obfuscated_alias_maker'
+require_relative 'active_record_provider/safe_alias_maker'
+
+module Dbee
+  module Providers
+    # Provider which leverages ActiveRecord and Arel for generating SQL.
+    class ActiveRecordProvider
+      DEFAULT_TABLE_PREFIX  = 't'
+      DEFAULT_COLUMN_PREFIX = 'c'
+
+      attr_reader :readable, :table_alias_maker, :column_alias_maker
+
+      def initialize(
+        readable: true,
+        table_prefix: DEFAULT_TABLE_PREFIX,
+        column_prefix: DEFAULT_COLUMN_PREFIX
+      )
+        @readable           = readable
+        @table_alias_maker  = alias_maker(table_prefix)
+        @column_alias_maker = alias_maker(column_prefix)
+      end
+
+      def sql(model, query)
+        ExpressionBuilder.new(
+          model,
+          table_alias_maker,
+          column_alias_maker
+        ).add(query).to_sql
+      end
+
+      private
+
+      def alias_maker(prefix)
+        readable ? SafeAliasMaker.new : ObfuscatedAliasMaker.new(prefix)
+      end
+    end
+  end
+end

--- a/lib/dbee/providers/active_record_provider/expression_builder.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require_relative 'expression_builder/constraint_maker'
+require_relative 'expression_builder/order_maker'
+require_relative 'expression_builder/select_maker'
+require_relative 'expression_builder/where_maker'
+
+module Dbee
+  module Providers
+    class ActiveRecordProvider
+      # This class can generate an Arel expression tree.
+      class ExpressionBuilder
+        extend Forwardable
+
+        def_delegators :statement, :to_sql
+
+        def initialize(model, table_alias_maker, column_alias_maker)
+          @model              = model
+          @table_alias_maker  = table_alias_maker
+          @column_alias_maker = column_alias_maker
+
+          @base_table = Arel::Table.new(model.table)
+          @base_table.table_alias = table_alias_maker.make(model.name)
+
+          @statement = base_table
+        end
+
+        def add(query)
+          query.fields.each   { |field| add_field(field) }
+          query.sorters.each  { |sorter| add_sorter(sorter) }
+          query.filters.each  { |filter| add_filter(filter) }
+
+          add_limit(query.limit)
+
+          self
+        end
+
+        private
+
+        attr_reader :base_table,
+                    :statement,
+                    :model,
+                    :table_alias_maker,
+                    :column_alias_maker
+
+        def tables
+          @tables ||= {}
+        end
+
+        def key_paths_to_arel_columns
+          @key_paths_to_arel_columns ||= {}
+        end
+
+        def key_paths_to_model_columns
+          @key_paths_to_model_columns ||= {}
+        end
+
+        def where_maker
+          @where_maker ||= WhereMaker.new
+        end
+
+        def order_maker
+          @order_maker ||= OrderMaker.new
+        end
+
+        def select_maker
+          @select_maker ||= SelectMaker.new
+        end
+
+        def constraint_maker
+          @constraint_maker ||= ConstraintMaker.new
+        end
+
+        def add_filter(filter)
+          add_key_path(filter.key_path)
+
+          key_path      = filter.key_path
+          arel_column   = key_paths_to_arel_columns[key_path]
+          model_column  = key_paths_to_model_columns[key_path]
+
+          predicate = where_maker.make(filter, arel_column, model_column)
+
+          @statement = statement.where(predicate)
+
+          self
+        end
+
+        def add_sorter(sorter)
+          add_key_path(sorter.key_path)
+
+          key_path = sorter.key_path
+          arel_column = key_paths_to_arel_columns[key_path]
+
+          predicate = order_maker.make(sorter, arel_column)
+
+          @statement = statement.order(predicate)
+
+          self
+        end
+
+        def add_field(field)
+          add_key_path(field.key_path)
+
+          key_path = field.key_path
+          arel_column = key_paths_to_arel_columns[key_path]
+
+          predicate = select_maker.make(field, arel_column, column_alias_maker)
+
+          @statement = statement.project(predicate)
+
+          self
+        end
+
+        def add_limit(limit)
+          @limit = limit ? limit.to_i : nil
+
+          @statement = @statement.take(limit) if limit
+
+          self
+        end
+
+        def model_column(ancestors, key_path)
+          model_column = (ancestors.values.last || model).column(key_path.column_name)
+          key_paths_to_model_columns[key_path] = model_column
+        end
+
+        def table(name, model, previous_table)
+          table = Arel::Table.new(model.table)
+          table.table_alias = table_alias_maker.make(name)
+
+          on = constraint_maker.make(model.constraints, table, previous_table)
+
+          @statement = statement.join(table, ::Arel::Nodes::OuterJoin)
+          @statement = statement.on(on) if on
+
+          tables[name] = table
+        end
+
+        def traverse_ancestors(ancestors)
+          ancestors.each_pair.inject(base_table) do |memo, (name, model)|
+            tables.key?(name) ? tables[name] : table(name, model, memo)
+          end
+        end
+
+        def add_key_path(key_path)
+          return if key_paths_to_arel_columns.key?(key_path)
+
+          ancestors = model.ancestors(key_path.ancestor_names)
+
+          model_column(ancestors, key_path)
+
+          table = traverse_ancestors(ancestors)
+
+          arel_column = table[key_path.column_name]
+          key_paths_to_arel_columns[key_path] = arel_column
+
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/dbee/providers/active_record_provider/expression_builder.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder.rb
@@ -58,10 +58,6 @@ module Dbee
           @key_paths_to_arel_columns ||= {}
         end
 
-        def key_paths_to_model_columns
-          @key_paths_to_model_columns ||= {}
-        end
-
         def where_maker
           @where_maker ||= WhereMaker.new
         end
@@ -81,11 +77,10 @@ module Dbee
         def add_filter(filter)
           add_key_path(filter.key_path)
 
-          key_path      = filter.key_path
-          arel_column   = key_paths_to_arel_columns[key_path]
-          model_column  = key_paths_to_model_columns[key_path]
+          key_path    = filter.key_path
+          arel_column = key_paths_to_arel_columns[key_path]
 
-          predicate = where_maker.make(filter, arel_column, model_column)
+          predicate = where_maker.make(filter, arel_column)
 
           @statement = statement.where(predicate)
 
@@ -126,11 +121,6 @@ module Dbee
           self
         end
 
-        def model_column(ancestors, key_path)
-          model_column = (ancestors.values.last || model).column(key_path.column_name)
-          key_paths_to_model_columns[key_path] = model_column
-        end
-
         def table(name, model, previous_table)
           table = Arel::Table.new(model.table)
           table.table_alias = table_alias_maker.make(name)
@@ -153,8 +143,6 @@ module Dbee
           return if key_paths_to_arel_columns.key?(key_path)
 
           ancestors = model.ancestors(key_path.ancestor_names)
-
-          model_column(ancestors, key_path)
 
           table = traverse_ancestors(ancestors)
 

--- a/lib/dbee/providers/active_record_provider/expression_builder/constraint_maker.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder/constraint_maker.rb
@@ -17,7 +17,7 @@ module Dbee
             on ? on.and(arel_column.eq(value)) : arel_column.eq(value)
           end
 
-          METHODS = {
+          CONSTRAINT_RESOLVERS = {
             Model::Constraints::Reference => lambda do |constraint, on, table, previous_table|
               name    = constraint.name
               parent  = constraint.parent
@@ -32,11 +32,11 @@ module Dbee
             end
           }.freeze
 
-          private_constant :METHODS
+          private_constant :CONSTRAINT_RESOLVERS
 
           def make(constraints, table, previous_table)
             constraints.inject(nil) do |memo, constraint|
-              method = METHODS[constraint.class]
+              method = CONSTRAINT_RESOLVERS[constraint.class]
 
               raise ArgumentError, "constraint unhandled: #{constraint.class.name}" unless method
 

--- a/lib/dbee/providers/active_record_provider/expression_builder/constraint_maker.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder/constraint_maker.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Dbee
+  module Providers
+    class ActiveRecordProvider
+      class ExpressionBuilder
+        # Can derive constraints for Arel table JOIN statements.
+        class ConstraintMaker
+          CONCAT_METHOD = lambda do |on, arel_column, value|
+            on ? on.and(arel_column.eq(value)) : arel_column.eq(value)
+          end
+
+          METHODS = {
+            Model::Constraints::Reference => lambda do |constraint, on, table, previous_table|
+              name    = constraint.name
+              parent  = constraint.parent
+
+              CONCAT_METHOD.call(on, table[name], previous_table[parent])
+            end,
+            Model::Constraints::Static => lambda do |constraint, on, table, _previous_table|
+              name  = constraint.name
+              value = constraint.value
+
+              CONCAT_METHOD.call(on, table[name], value)
+            end
+          }.freeze
+
+          private_constant :METHODS
+
+          def make(constraints, table, previous_table)
+            constraints.inject(nil) do |memo, constraint|
+              method = METHODS[constraint.class]
+
+              raise ArgumentError, "constraint unhandled: #{constraint.class.name}" unless method
+
+              method.call(constraint, memo, table, previous_table)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dbee/providers/active_record_provider/expression_builder/order_maker.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder/order_maker.rb
@@ -10,7 +10,14 @@
 module Dbee
   module Providers
     class ActiveRecordProvider
-      VERSION = '1.0.0-alpha'
+      class ExpressionBuilder
+        # Derives Arel#order predicates.
+        class OrderMaker
+          def make(sorter, arel_column)
+            sorter.ascending? ? arel_column : arel_column.desc
+          end
+        end
+      end
     end
   end
 end

--- a/lib/dbee/providers/active_record_provider/expression_builder/select_maker.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder/select_maker.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Dbee
+  module Providers
+    class ActiveRecordProvider
+      class ExpressionBuilder
+        # Derives Arel#project predicates.
+        class SelectMaker
+          def make(column, arel_column, alias_maker)
+            column_alias = quote(alias_maker.make(column.display))
+
+            arel_column.as(column_alias)
+          end
+
+          private
+
+          def quote(value)
+            ActiveRecord::Base.connection.quote(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dbee/providers/active_record_provider/expression_builder/where_maker.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder/where_maker.rb
@@ -13,7 +13,7 @@ module Dbee
       class ExpressionBuilder
         # Derives Arel#where predicates.
         class WhereMaker
-          METHODS = {
+          FILTER_EVALUATORS = {
             Query::Filters::Contains => ->(column, val) { column.matches("%#{val}%") },
             Query::Filters::Equals => ->(column, val) { column.eq(val) },
             Query::Filters::GreaterThan => ->(column, val) { column.gt(val) },
@@ -26,11 +26,11 @@ module Dbee
             Query::Filters::StartsWith => ->(column, val) { column.matches("#{val}%") }
           }.freeze
 
-          private_constant :METHODS
+          private_constant :FILTER_EVALUATORS
 
           def make(filter, arel_column)
             predicates = normalize(filter.value).map do |coerced_value|
-              method = METHODS[filter.class]
+              method = FILTER_EVALUATORS[filter.class]
 
               raise ArgumentError, "cannot compile filter: #{filter}" unless method
 

--- a/lib/dbee/providers/active_record_provider/expression_builder/where_maker.rb
+++ b/lib/dbee/providers/active_record_provider/expression_builder/where_maker.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Dbee
+  module Providers
+    class ActiveRecordProvider
+      class ExpressionBuilder
+        # Derives Arel#where predicates.
+        class WhereMaker
+          METHODS = {
+            Query::Filters::Contains => ->(column, val) { column.matches("%#{val}%") },
+            Query::Filters::Equals => ->(column, val) { column.eq(val) },
+            Query::Filters::GreaterThan => ->(column, val) { column.gt(val) },
+            Query::Filters::GreaterThanOrEqualTo => ->(column, val) { column.gteq(val) },
+            Query::Filters::LessThan => ->(column, val) { column.lt(val) },
+            Query::Filters::LessThanOrEqualTo => ->(column, val) { column.lteq(val) },
+            Query::Filters::NotContain => ->(column, val) { column.does_not_match("%#{val}%") },
+            Query::Filters::NotEquals => ->(column, val) { column.not_eq(val) },
+            Query::Filters::NotStartWith => ->(column, val) { column.does_not_match("#{val}%") },
+            Query::Filters::StartsWith => ->(column, val) { column.matches("#{val}%") }
+          }.freeze
+
+          private_constant :METHODS
+
+          def make(filter, arel_column, model_column)
+            coerced_values = Array(filter.value).map { |v| model_column.coerce(v) }
+
+            predicates = coerced_values.map do |coerced_value|
+              method = METHODS[filter.class]
+
+              raise ArgumentError, "cannot compile filter: #{filter}" unless method
+
+              method.call(arel_column, coerced_value)
+            end
+
+            clause = predicates.shift
+
+            predicates.each do |predicate|
+              clause = clause.or(predicate)
+            end
+
+            clause
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dbee/providers/active_record_provider/obfuscated_alias_maker.rb
+++ b/lib/dbee/providers/active_record_provider/obfuscated_alias_maker.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Dbee
+  module Providers
+    class ActiveRecordProvider
+      # Derives new alias names and keeps count of ones already generated in order to avoid
+      # collision.
+      class ObfuscatedAliasMaker
+        attr_reader :prefix
+
+        def initialize(prefix = '')
+          @counter  = -1
+          @prefix   = prefix
+        end
+
+        def make(_name)
+          increment
+          current
+        end
+
+        private
+
+        def current
+          "#{prefix}#{@counter}"
+        end
+
+        def increment
+          @counter += 1
+        end
+      end
+    end
+  end
+end

--- a/lib/dbee/providers/active_record_provider/safe_alias_maker.rb
+++ b/lib/dbee/providers/active_record_provider/safe_alias_maker.rb
@@ -10,7 +10,12 @@
 module Dbee
   module Providers
     class ActiveRecordProvider
-      VERSION = '1.0.0-alpha'
+      # This class can be used when readable alias names are expected.
+      class SafeAliasMaker
+        def make(name)
+          name.to_s.tr('.', '_')
+        end
+      end
     end
   end
 end

--- a/lib/dbee/providers/active_record_provider/version.rb
+++ b/lib/dbee/providers/active_record_provider/version.rb
@@ -10,7 +10,7 @@
 module Dbee
   module Providers
     class ActiveRecordProvider
-      VERSION = '1.0.0-alpha'
+      VERSION = '1.0.0-alpha.1'
     end
   end
 end

--- a/lib/dbee/providers/active_record_provider/version.rb
+++ b/lib/dbee/providers/active_record_provider/version.rb
@@ -10,7 +10,7 @@
 module Dbee
   module Providers
     class ActiveRecordProvider
-      VERSION = '1.0.0-alpha.2'
+      VERSION = '1.0.0'
     end
   end
 end

--- a/lib/dbee/providers/active_record_provider/version.rb
+++ b/lib/dbee/providers/active_record_provider/version.rb
@@ -10,7 +10,7 @@
 module Dbee
   module Providers
     class ActiveRecordProvider
-      VERSION = '1.0.0-alpha.1'
+      VERSION = '1.0.0-alpha.2'
     end
   end
 end

--- a/spec/config/database.yaml.ci
+++ b/spec/config/database.yaml.ci
@@ -1,0 +1,9 @@
+sqlite:
+  adapter: sqlite3
+  database: ':memory:'
+mysql:
+  adapter: mysql2
+  database: dbee_test
+  username: root
+  host: 127.0.0.1
+  port: 3306

--- a/spec/db_helper.rb
+++ b/spec/db_helper.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2018-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+# Enable logging using something like:
+# ActiveRecord::Base.logger = Logger.new(STDERR)
+
+def connect_to_db(name)
+  config = yaml_file_read('spec', 'config', 'database.yaml')[name.to_s]
+  ActiveRecord::Base.establish_connection(config)
+end
+
+def load_schema
+  ActiveRecord::Schema.define do
+    create_table :theaters do |t|
+      t.column :name, :string
+      t.column :partition, :string
+      t.column :active, :boolean
+      t.column :inspected, :boolean
+      t.timestamps
+    end
+
+    create_table :members do |t|
+      t.column :tid, :integer
+      t.column :account_number, :string
+      t.column :partition, :string
+      t.timestamps
+    end
+
+    create_table :demographics do |t|
+      t.column :member_id, :integer
+      t.column :name, :string
+      t.timestamps
+    end
+
+    create_table :phone_numbers do |t|
+      t.column :demographic_id, :integer
+      t.column :phone_type, :string
+      t.column :phone_number, :string
+      t.timestamps
+    end
+
+    create_table :movies do |t|
+      t.column :member_id, :integer
+      t.column :name, :string
+      t.column :genre, :string
+      t.column :favorite, :boolean, default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/spec/dbee/providers/active_record_provider_spec.rb
+++ b/spec/dbee/providers/active_record_provider_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+require 'db_helper'
+
+describe Dbee::Providers::ActiveRecordProvider do
+  let(:models) { yaml_fixture('models.yaml') }
+
+  describe 'Snapshot' do
+    context 'Generating SQL' do
+      %w[sqlite mysql].each do |dbms|
+        context dbms do
+          before(:all) do
+            connect_to_db(dbms)
+          end
+
+          { readable: true, not_readable: false }.each_pair do |type, readable|
+            context type.to_s do
+              let(:key) { "#{dbms}_#{type}" }
+
+              yaml_fixture_files('active_record_snapshots').each_pair do |filename, snapshot|
+                specify File.basename(filename) do
+                  model_name = snapshot['model_name']
+                  query = Dbee::Query.make(snapshot['query'])
+                  model = Dbee::Model.make(models[model_name])
+                  expected_sql  = snapshot[key].to_s.chomp.tr("\n", ' ')
+                  actual_sql    = described_class.new(readable: readable).sql(model, query)
+
+                  error_msg = <<~ERROR_MSG
+                    Expected: #{expected_sql}
+                    Actual:   #{actual_sql}
+                  ERROR_MSG
+
+                  expect(actual_sql).to eq(expected_sql), error_msg
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'Executing SQL' do
+      %w[sqlite].each do |dbms|
+        context dbms do
+          before(:all) do
+            connect_to_db(dbms)
+            load_schema
+          end
+
+          { readable: true, not_readable: false }.each_pair do |type, readable|
+            context type.to_s do
+              let(:key) { "#{dbms}_#{type}" }
+
+              yaml_fixture_files('active_record_snapshots').each_pair do |filename, snapshot|
+                specify File.basename(filename) do
+                  model_name = snapshot['model_name']
+                  query = Dbee::Query.make(snapshot['query'])
+                  model = Dbee::Model.make(models[model_name])
+
+                  sql = described_class.new(readable: readable).sql(model, query)
+
+                  expect { ActiveRecord::Base.connection.execute(sql) }.to_not raise_error
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dbee/providers/active_record_provider_spec.rb
+++ b/spec/dbee/providers/active_record_provider_spec.rb
@@ -30,8 +30,8 @@ describe Dbee::Providers::ActiveRecordProvider do
                   model_name = snapshot['model_name']
                   query = Dbee::Query.make(snapshot['query'])
                   model = Dbee::Model.make(models[model_name])
-                  expected_sql  = snapshot[key].to_s.chomp.tr("\n", ' ')
-                  actual_sql    = described_class.new(readable: readable).sql(model, query)
+                  expected_sql = snapshot[key].to_s.chomp.tr("\n", ' ')
+                  actual_sql = described_class.new(readable: readable).sql(model, query)
 
                   error_msg = <<~ERROR_MSG
                     Expected: #{expected_sql}

--- a/spec/fixtures/active_record_snapshots/five_table_query.yaml
+++ b/spec/fixtures/active_record_snapshots/five_table_query.yaml
@@ -1,0 +1,77 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: members.demos.phone_numbers.phone_number
+      display: PHONE NUMBER
+    - key_path: members.demos.name
+    - key_path: id
+    - key_path: name
+    - key_path: members.movies.id
+    - key_path: members.id
+    - key_path: members.account_number
+    - key_path: members.demos.phone_numbers.phone_type
+    - key_path: members.movies.name
+sqlite_readable: |+
+  SELECT
+  "members_demos_phone_numbers"."phone_number" AS 'PHONE NUMBER',
+  "members_demos"."name" AS 'members_demos_name',
+  "theaters"."id" AS 'id',
+  "theaters"."name" AS 'name',
+  "members_movies"."id" AS 'members_movies_id',
+  "members"."id" AS 'members_id',
+  "members"."account_number" AS 'members_account_number',
+  "members_demos_phone_numbers"."phone_type" AS 'members_demos_phone_numbers_phone_type',
+  "members_movies"."name" AS 'members_movies_name'
+  FROM "theaters" "theaters"
+  LEFT OUTER JOIN "members" "members" ON "members"."tid" = "theaters"."id" AND "members"."partition" = "theaters"."partition"
+  LEFT OUTER JOIN "demographics" "members_demos" ON "members_demos"."member_id" = "members"."id"
+  LEFT OUTER JOIN "phone_numbers" "members_demos_phone_numbers" ON "members_demos_phone_numbers"."demographic_id" = "members_demos"."id"
+  LEFT OUTER JOIN "movies" "members_movies" ON "members_movies"."member_id" = "members"."id"
+sqlite_not_readable: |+
+  SELECT
+  "t3"."phone_number" AS 'c0',
+  "t2"."name" AS 'c1',
+  "t0"."id" AS 'c2',
+  "t0"."name" AS 'c3',
+  "t4"."id" AS 'c4',
+  "t1"."id" AS 'c5',
+  "t1"."account_number" AS 'c6',
+  "t3"."phone_type" AS 'c7',
+  "t4"."name" AS 'c8'
+  FROM "theaters" "t0"
+  LEFT OUTER JOIN "members" "t1" ON "t1"."tid" = "t0"."id" AND "t1"."partition" = "t0"."partition"
+  LEFT OUTER JOIN "demographics" "t2" ON "t2"."member_id" = "t1"."id"
+  LEFT OUTER JOIN "phone_numbers" "t3" ON "t3"."demographic_id" = "t2"."id"
+  LEFT OUTER JOIN "movies" "t4" ON "t4"."member_id" = "t1"."id"
+mysql_readable: |+
+  SELECT
+  `members_demos_phone_numbers`.`phone_number` AS 'PHONE NUMBER',
+  `members_demos`.`name` AS 'members_demos_name',
+  `theaters`.`id` AS 'id',
+  `theaters`.`name` AS 'name',
+  `members_movies`.`id` AS 'members_movies_id',
+  `members`.`id` AS 'members_id',
+  `members`.`account_number` AS 'members_account_number',
+  `members_demos_phone_numbers`.`phone_type` AS 'members_demos_phone_numbers_phone_type',
+  `members_movies`.`name` AS 'members_movies_name'
+  FROM `theaters` `theaters`
+  LEFT OUTER JOIN `members` `members` ON `members`.`tid` = `theaters`.`id` AND `members`.`partition` = `theaters`.`partition`
+  LEFT OUTER JOIN `demographics` `members_demos` ON `members_demos`.`member_id` = `members`.`id`
+  LEFT OUTER JOIN `phone_numbers` `members_demos_phone_numbers` ON `members_demos_phone_numbers`.`demographic_id` = `members_demos`.`id`
+  LEFT OUTER JOIN `movies` `members_movies` ON `members_movies`.`member_id` = `members`.`id`
+mysql_not_readable: |+
+  SELECT
+  `t3`.`phone_number` AS 'c0',
+  `t2`.`name` AS 'c1',
+  `t0`.`id` AS 'c2',
+  `t0`.`name` AS 'c3',
+  `t4`.`id` AS 'c4',
+  `t1`.`id` AS 'c5',
+  `t1`.`account_number` AS 'c6',
+  `t3`.`phone_type` AS 'c7',
+  `t4`.`name` AS 'c8'
+  FROM `theaters` `t0`
+  LEFT OUTER JOIN `members` `t1` ON `t1`.`tid` = `t0`.`id` AND `t1`.`partition` = `t0`.`partition`
+  LEFT OUTER JOIN `demographics` `t2` ON `t2`.`member_id` = `t1`.`id`
+  LEFT OUTER JOIN `phone_numbers` `t3` ON `t3`.`demographic_id` = `t2`.`id`
+  LEFT OUTER JOIN `movies` `t4` ON `t4`.`member_id` = `t1`.`id`

--- a/spec/fixtures/active_record_snapshots/multiple_same_table_query_with_static_constraints.yaml
+++ b/spec/fixtures/active_record_snapshots/multiple_same_table_query_with_static_constraints.yaml
@@ -1,0 +1,104 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+    - key_path: name
+    - key_path: members.id
+    - key_path: members.account_number
+    - key_path: members.movies.id
+    - key_path: members.movies.name
+      display: 'Movie Name'
+    - key_path: members.movies.genre
+    - key_path: members.favorite_comic_movies.id
+    - key_path: members.favorite_comic_movies.name
+      display: 'Favorite Comic Movie Name'
+    - key_path: members.favorite_comic_movies.genre
+    - key_path: members.favorite_mystery_movies.id
+    - key_path: members.favorite_mystery_movies.name
+      display: 'Favorite Mystery Movie Name'
+    - key_path: members.favorite_mystery_movies.genre
+  limit: 12
+sqlite_readable: |+
+  SELECT
+   "theaters"."id" AS 'id',
+  "theaters"."name" AS 'name',
+  "members"."id" AS 'members_id',
+  "members"."account_number" AS 'members_account_number',
+  "members_movies"."id" AS 'members_movies_id',
+  "members_movies"."name" AS 'Movie Name',
+  "members_movies"."genre" AS 'members_movies_genre',
+  "members_favorite_comic_movies"."id" AS 'members_favorite_comic_movies_id',
+  "members_favorite_comic_movies"."name" AS 'Favorite Comic Movie Name',
+  "members_favorite_comic_movies"."genre" AS 'members_favorite_comic_movies_genre',
+  "members_favorite_mystery_movies"."id" AS 'members_favorite_mystery_movies_id',
+  "members_favorite_mystery_movies"."name" AS 'Favorite Mystery Movie Name',
+  "members_favorite_mystery_movies"."genre" AS 'members_favorite_mystery_movies_genre'
+  FROM "theaters" "theaters"
+  LEFT OUTER JOIN "members" "members" ON "members"."tid" = "theaters"."id" AND "members"."partition" = "theaters"."partition"
+  LEFT OUTER JOIN "movies" "members_movies" ON "members_movies"."member_id" = "members"."id"
+  LEFT OUTER JOIN "movies" "members_favorite_comic_movies" ON "members_favorite_comic_movies"."member_id" = "members"."id" AND "members_favorite_comic_movies"."genre" = 'comic'
+  LEFT OUTER JOIN "movies" "members_favorite_mystery_movies" ON "members_favorite_mystery_movies"."member_id" = "members"."id" AND "members_favorite_mystery_movies"."genre" = 'mystery'
+  LIMIT 12
+sqlite_not_readable: |+
+  SELECT
+   "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1',
+  "t1"."id" AS 'c2',
+  "t1"."account_number" AS 'c3',
+  "t2"."id" AS 'c4',
+  "t2"."name" AS 'c5',
+  "t2"."genre" AS 'c6',
+  "t3"."id" AS 'c7',
+  "t3"."name" AS 'c8',
+  "t3"."genre" AS 'c9',
+  "t4"."id" AS 'c10',
+  "t4"."name" AS 'c11',
+  "t4"."genre" AS 'c12'
+  FROM "theaters" "t0"
+  LEFT OUTER JOIN "members" "t1" ON "t1"."tid" = "t0"."id" AND "t1"."partition" = "t0"."partition"
+  LEFT OUTER JOIN "movies" "t2" ON "t2"."member_id" = "t1"."id"
+  LEFT OUTER JOIN "movies" "t3" ON "t3"."member_id" = "t1"."id" AND "t3"."genre" = 'comic'
+  LEFT OUTER JOIN "movies" "t4" ON "t4"."member_id" = "t1"."id" AND "t4"."genre" = 'mystery'
+  LIMIT 12
+mysql_readable: |+
+  SELECT
+   `theaters`.`id` AS 'id',
+  `theaters`.`name` AS 'name',
+  `members`.`id` AS 'members_id',
+  `members`.`account_number` AS 'members_account_number',
+  `members_movies`.`id` AS 'members_movies_id',
+  `members_movies`.`name` AS 'Movie Name',
+  `members_movies`.`genre` AS 'members_movies_genre',
+  `members_favorite_comic_movies`.`id` AS 'members_favorite_comic_movies_id',
+  `members_favorite_comic_movies`.`name` AS 'Favorite Comic Movie Name',
+  `members_favorite_comic_movies`.`genre` AS 'members_favorite_comic_movies_genre',
+  `members_favorite_mystery_movies`.`id` AS 'members_favorite_mystery_movies_id',
+  `members_favorite_mystery_movies`.`name` AS 'Favorite Mystery Movie Name',
+  `members_favorite_mystery_movies`.`genre` AS 'members_favorite_mystery_movies_genre'
+  FROM `theaters` `theaters`
+  LEFT OUTER JOIN `members` `members` ON `members`.`tid` = `theaters`.`id` AND `members`.`partition` = `theaters`.`partition`
+  LEFT OUTER JOIN `movies` `members_movies` ON `members_movies`.`member_id` = `members`.`id`
+  LEFT OUTER JOIN `movies` `members_favorite_comic_movies` ON `members_favorite_comic_movies`.`member_id` = `members`.`id` AND `members_favorite_comic_movies`.`genre` = 'comic'
+  LEFT OUTER JOIN `movies` `members_favorite_mystery_movies` ON `members_favorite_mystery_movies`.`member_id` = `members`.`id` AND `members_favorite_mystery_movies`.`genre` = 'mystery'
+  LIMIT 12
+mysql_not_readable: |+
+  SELECT
+   `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1',
+  `t1`.`id` AS 'c2',
+  `t1`.`account_number` AS 'c3',
+  `t2`.`id` AS 'c4',
+  `t2`.`name` AS 'c5',
+  `t2`.`genre` AS 'c6',
+  `t3`.`id` AS 'c7',
+  `t3`.`name` AS 'c8',
+  `t3`.`genre` AS 'c9',
+  `t4`.`id` AS 'c10',
+  `t4`.`name` AS 'c11',
+  `t4`.`genre` AS 'c12'
+  FROM `theaters` `t0`
+  LEFT OUTER JOIN `members` `t1` ON `t1`.`tid` = `t0`.`id` AND `t1`.`partition` = `t0`.`partition`
+  LEFT OUTER JOIN `movies` `t2` ON `t2`.`member_id` = `t1`.`id`
+  LEFT OUTER JOIN `movies` `t3` ON `t3`.`member_id` = `t1`.`id` AND `t3`.`genre` = 'comic'
+  LEFT OUTER JOIN `movies` `t4` ON `t4`.`member_id` = `t1`.`id` AND `t4`.`genre` = 'mystery'
+  LIMIT 12

--- a/spec/fixtures/active_record_snapshots/one_table_query.yaml
+++ b/spec/fixtures/active_record_snapshots/one_table_query.yaml
@@ -1,0 +1,26 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+      display: 'ID #'
+    - key_path: name
+sqlite_not_readable: |+
+  SELECT
+  "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1'
+  FROM "theaters" "t0"
+sqlite_readable: |+
+  SELECT
+  "theaters"."id" AS 'ID #',
+  "theaters"."name" AS 'name'
+  FROM "theaters" "theaters"
+mysql_not_readable: |+
+  SELECT
+  `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1'
+  FROM `theaters` `t0`
+mysql_readable: |+
+  SELECT
+  `theaters`.`id` AS 'ID #',
+  `theaters`.`name` AS 'name'
+  FROM `theaters` `theaters`

--- a/spec/fixtures/active_record_snapshots/one_table_query_with_ascending_sort.yaml
+++ b/spec/fixtures/active_record_snapshots/one_table_query_with_ascending_sort.yaml
@@ -1,0 +1,31 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+    - key_path: name
+  sorters:
+    - key_path: created_at
+sqlite_readable: |+
+  SELECT
+  "theaters"."id" AS 'id',
+  "theaters"."name" AS 'name'
+  FROM "theaters" "theaters"
+  ORDER BY "theaters"."created_at"
+sqlite_not_readable: |+
+  SELECT
+  "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1'
+  FROM "theaters" "t0"
+  ORDER BY "t0"."created_at"
+mysql_readable: |+
+  SELECT
+  `theaters`.`id` AS 'id',
+  `theaters`.`name` AS 'name'
+  FROM `theaters` `theaters`
+  ORDER BY `theaters`.`created_at`
+mysql_not_readable: |+
+  SELECT
+  `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1'
+  FROM `theaters` `t0`
+  ORDER BY `t0`.`created_at`

--- a/spec/fixtures/active_record_snapshots/one_table_query_with_descending_sort.yaml
+++ b/spec/fixtures/active_record_snapshots/one_table_query_with_descending_sort.yaml
@@ -1,0 +1,32 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+    - key_path: name
+  sorters:
+    - key_path: created_at
+      direction: descending
+sqlite_readable: |+
+  SELECT
+  "theaters"."id" AS 'id',
+  "theaters"."name" AS 'name'
+  FROM "theaters" "theaters"
+  ORDER BY "theaters"."created_at" DESC
+sqlite_not_readable: |+
+  SELECT
+  "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1'
+  FROM "theaters" "t0"
+  ORDER BY "t0"."created_at" DESC
+mysql_readable: |+
+  SELECT
+  `theaters`.`id` AS 'id',
+  `theaters`.`name` AS 'name'
+  FROM `theaters` `theaters`
+  ORDER BY `theaters`.`created_at` DESC
+mysql_not_readable: |+
+  SELECT
+  `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1'
+  FROM `theaters` `t0`
+  ORDER BY `t0`.`created_at` DESC

--- a/spec/fixtures/active_record_snapshots/one_table_query_with_filters.yaml
+++ b/spec/fixtures/active_record_snapshots/one_table_query_with_filters.yaml
@@ -21,22 +21,13 @@ query:
       value: 'false' # notice how the value is a string, but the data model should be setup to be a boolean
     - type: equals
       key_path: active
-      value:
-        - false
-        - true
-        - null
-        - 'y'
-        - 'n'
-        - ''
+      value: [ true, false, [ null ] ] # test out nested value arrays
     - type: equals
       key_path: inspected
       value:
         - false
         - true
         - null
-        - 'y'
-        - 'n'
-        - ''
     - type: less_than_or_equal_to
       value: '2019-03-04'
       key_path: created_at
@@ -65,24 +56,15 @@ query:
         - 'hu'
       key_path: name
 sqlite_readable: |+
-  SELECT
-  "theaters"."id" AS 'ID #',
+  SELECT "theaters"."id" AS 'ID #',
   "theaters"."name" AS 'name'
   FROM "theaters" "theaters"
-  WHERE
-  ("theaters"."name" = 'AMC' OR "theaters"."name" = 'Regal') AND
+  WHERE ("theaters"."name" = 'AMC' OR "theaters"."name" = 'Regal') AND
   "theaters"."name" LIKE 'A%' AND
   "theaters"."name" LIKE '%m%' AND
-  "theaters"."active" = 'f' AND
-  ((((("theaters"."active" = 'f' OR "theaters"."active" = 't') OR
-  "theaters"."active" = 'f') OR "theaters"."active" = 't') OR
-  "theaters"."active" = 'f') OR
-  "theaters"."active" = 'f') AND
-  ((((("theaters"."inspected" = 'f' OR "theaters"."inspected" = 't') OR
-  "theaters"."inspected" IS NULL) OR
-  "theaters"."inspected" = 't') OR
-  "theaters"."inspected" = 'f') OR
-  "theaters"."inspected" IS NULL) AND
+  "theaters"."active" = 'false' AND
+  (("theaters"."active" = 't' OR "theaters"."active" = 'f') OR "theaters"."active" IS NULL) AND
+  (("theaters"."inspected" = 'f' OR "theaters"."inspected" = 't') OR "theaters"."inspected" IS NULL) AND
   "theaters"."created_at" <= '2019-03-04' AND
   "theaters"."created_at" < '2018-03-04' AND
   "theaters"."created_at" >= '2001-03-04' AND
@@ -91,24 +73,15 @@ sqlite_readable: |+
   ("theaters"."name" NOT LIKE '%tfli%' OR "theaters"."name" NOT LIKE '%ul%') AND
   ("theaters"."name" NOT LIKE 'netf%' OR "theaters"."name" NOT LIKE 'hu%')
 sqlite_not_readable: |+
-  SELECT
-  "t0"."id" AS 'c0',
+  SELECT "t0"."id" AS 'c0',
   "t0"."name" AS 'c1'
   FROM "theaters" "t0"
-  WHERE
-  ("t0"."name" = 'AMC' OR "t0"."name" = 'Regal') AND
+  WHERE ("t0"."name" = 'AMC' OR "t0"."name" = 'Regal') AND
   "t0"."name" LIKE 'A%' AND
   "t0"."name" LIKE '%m%' AND
-  "t0"."active" = 'f' AND
-  ((((("t0"."active" = 'f' OR "t0"."active" = 't') OR
-  "t0"."active" = 'f') OR "t0"."active" = 't') OR
-  "t0"."active" = 'f') OR
-  "t0"."active" = 'f') AND
-  ((((("t0"."inspected" = 'f' OR "t0"."inspected" = 't') OR
-  "t0"."inspected" IS NULL) OR
-  "t0"."inspected" = 't') OR
-  "t0"."inspected" = 'f') OR
-  "t0"."inspected" IS NULL) AND
+  "t0"."active" = 'false' AND
+  (("t0"."active" = 't' OR "t0"."active" = 'f') OR "t0"."active" IS NULL) AND
+  (("t0"."inspected" = 'f' OR "t0"."inspected" = 't') OR "t0"."inspected" IS NULL) AND
   "t0"."created_at" <= '2019-03-04' AND
   "t0"."created_at" < '2018-03-04' AND
   "t0"."created_at" >= '2001-03-04' AND
@@ -117,24 +90,15 @@ sqlite_not_readable: |+
   ("t0"."name" NOT LIKE '%tfli%' OR "t0"."name" NOT LIKE '%ul%') AND
   ("t0"."name" NOT LIKE 'netf%' OR "t0"."name" NOT LIKE 'hu%')
 mysql_readable: |+
-  SELECT
-  `theaters`.`id` AS 'ID #',
+  SELECT `theaters`.`id` AS 'ID #',
   `theaters`.`name` AS 'name'
   FROM `theaters` `theaters`
-  WHERE
-  (`theaters`.`name` = 'AMC' OR `theaters`.`name` = 'Regal') AND
+  WHERE (`theaters`.`name` = 'AMC' OR `theaters`.`name` = 'Regal') AND
   `theaters`.`name` LIKE 'A%' AND
   `theaters`.`name` LIKE '%m%' AND
-  `theaters`.`active` = FALSE AND
-  (((((`theaters`.`active` = FALSE OR `theaters`.`active` = TRUE) OR
-  `theaters`.`active` = FALSE) OR `theaters`.`active` = TRUE) OR
-  `theaters`.`active` = FALSE) OR
-  `theaters`.`active` = FALSE) AND
-  (((((`theaters`.`inspected` = FALSE OR `theaters`.`inspected` = TRUE) OR
-  `theaters`.`inspected` IS NULL) OR
-  `theaters`.`inspected` = TRUE) OR
-  `theaters`.`inspected` = FALSE) OR
-  `theaters`.`inspected` IS NULL) AND
+  `theaters`.`active` = 'false' AND
+  ((`theaters`.`active` = TRUE OR `theaters`.`active` = FALSE) OR `theaters`.`active` IS NULL) AND
+  ((`theaters`.`inspected` = FALSE OR `theaters`.`inspected` = TRUE) OR `theaters`.`inspected` IS NULL) AND
   `theaters`.`created_at` <= '2019-03-04' AND
   `theaters`.`created_at` < '2018-03-04' AND
   `theaters`.`created_at` >= '2001-03-04' AND
@@ -143,24 +107,15 @@ mysql_readable: |+
   (`theaters`.`name` NOT LIKE '%tfli%' OR `theaters`.`name` NOT LIKE '%ul%') AND
   (`theaters`.`name` NOT LIKE 'netf%' OR `theaters`.`name` NOT LIKE 'hu%')
 mysql_not_readable: |+
-  SELECT
-  `t0`.`id` AS 'c0',
+  SELECT `t0`.`id` AS 'c0',
   `t0`.`name` AS 'c1'
   FROM `theaters` `t0`
-  WHERE
-  (`t0`.`name` = 'AMC' OR `t0`.`name` = 'Regal') AND
+  WHERE (`t0`.`name` = 'AMC' OR `t0`.`name` = 'Regal') AND
   `t0`.`name` LIKE 'A%' AND
   `t0`.`name` LIKE '%m%' AND
-  `t0`.`active` = FALSE AND
-  (((((`t0`.`active` = FALSE OR `t0`.`active` = TRUE) OR
-  `t0`.`active` = FALSE) OR `t0`.`active` = TRUE) OR
-  `t0`.`active` = FALSE) OR
-  `t0`.`active` = FALSE) AND
-  (((((`t0`.`inspected` = FALSE OR `t0`.`inspected` = TRUE) OR
-  `t0`.`inspected` IS NULL) OR
-  `t0`.`inspected` = TRUE) OR
-  `t0`.`inspected` = FALSE) OR
-  `t0`.`inspected` IS NULL) AND
+  `t0`.`active` = 'false' AND
+  ((`t0`.`active` = TRUE OR `t0`.`active` = FALSE) OR `t0`.`active` IS NULL) AND
+  ((`t0`.`inspected` = FALSE OR `t0`.`inspected` = TRUE) OR `t0`.`inspected` IS NULL) AND
   `t0`.`created_at` <= '2019-03-04' AND
   `t0`.`created_at` < '2018-03-04' AND
   `t0`.`created_at` >= '2001-03-04' AND

--- a/spec/fixtures/active_record_snapshots/one_table_query_with_filters.yaml
+++ b/spec/fixtures/active_record_snapshots/one_table_query_with_filters.yaml
@@ -1,0 +1,170 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+      display: 'ID #'
+    - key_path: name
+  filters:
+    - type: equals
+      key_path: name
+      value:
+        - AMC
+        - Regal
+    - type: starts_with
+      key_path: name
+      value: A
+    - type: contains
+      key_path: name
+      value: m
+    - type: equals
+      key_path: active
+      value: 'false' # notice how the value is a string, but the data model should be setup to be a boolean
+    - type: equals
+      key_path: active
+      value:
+        - false
+        - true
+        - null
+        - 'y'
+        - 'n'
+        - ''
+    - type: equals
+      key_path: inspected
+      value:
+        - false
+        - true
+        - null
+        - 'y'
+        - 'n'
+        - ''
+    - type: less_than_or_equal_to
+      value: '2019-03-04'
+      key_path: created_at
+    - type: less_than
+      value: '2018-03-04'
+      key_path: created_at
+    - type: greater_than_or_equal_to
+      value: '2001-03-04'
+      key_path: created_at
+    - type: greater_than
+      value: '2002-03-04'
+      key_path: created_at
+    - type: not_equals
+      value:
+        - 'Netflix'
+        - 'Hulu'
+      key_path: name
+    - type: not_contain
+      value:
+        - 'tfli'
+        - 'ul'
+      key_path: name
+    - type: not_start_with
+      value:
+        - 'netf'
+        - 'hu'
+      key_path: name
+sqlite_readable: |+
+  SELECT
+  "theaters"."id" AS 'ID #',
+  "theaters"."name" AS 'name'
+  FROM "theaters" "theaters"
+  WHERE
+  ("theaters"."name" = 'AMC' OR "theaters"."name" = 'Regal') AND
+  "theaters"."name" LIKE 'A%' AND
+  "theaters"."name" LIKE '%m%' AND
+  "theaters"."active" = 'f' AND
+  ((((("theaters"."active" = 'f' OR "theaters"."active" = 't') OR
+  "theaters"."active" = 'f') OR "theaters"."active" = 't') OR
+  "theaters"."active" = 'f') OR
+  "theaters"."active" = 'f') AND
+  ((((("theaters"."inspected" = 'f' OR "theaters"."inspected" = 't') OR
+  "theaters"."inspected" IS NULL) OR
+  "theaters"."inspected" = 't') OR
+  "theaters"."inspected" = 'f') OR
+  "theaters"."inspected" IS NULL) AND
+  "theaters"."created_at" <= '2019-03-04' AND
+  "theaters"."created_at" < '2018-03-04' AND
+  "theaters"."created_at" >= '2001-03-04' AND
+  "theaters"."created_at" > '2002-03-04' AND
+  ("theaters"."name" != 'Netflix' OR "theaters"."name" != 'Hulu') AND
+  ("theaters"."name" NOT LIKE '%tfli%' OR "theaters"."name" NOT LIKE '%ul%') AND
+  ("theaters"."name" NOT LIKE 'netf%' OR "theaters"."name" NOT LIKE 'hu%')
+sqlite_not_readable: |+
+  SELECT
+  "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1'
+  FROM "theaters" "t0"
+  WHERE
+  ("t0"."name" = 'AMC' OR "t0"."name" = 'Regal') AND
+  "t0"."name" LIKE 'A%' AND
+  "t0"."name" LIKE '%m%' AND
+  "t0"."active" = 'f' AND
+  ((((("t0"."active" = 'f' OR "t0"."active" = 't') OR
+  "t0"."active" = 'f') OR "t0"."active" = 't') OR
+  "t0"."active" = 'f') OR
+  "t0"."active" = 'f') AND
+  ((((("t0"."inspected" = 'f' OR "t0"."inspected" = 't') OR
+  "t0"."inspected" IS NULL) OR
+  "t0"."inspected" = 't') OR
+  "t0"."inspected" = 'f') OR
+  "t0"."inspected" IS NULL) AND
+  "t0"."created_at" <= '2019-03-04' AND
+  "t0"."created_at" < '2018-03-04' AND
+  "t0"."created_at" >= '2001-03-04' AND
+  "t0"."created_at" > '2002-03-04' AND
+  ("t0"."name" != 'Netflix' OR "t0"."name" != 'Hulu') AND
+  ("t0"."name" NOT LIKE '%tfli%' OR "t0"."name" NOT LIKE '%ul%') AND
+  ("t0"."name" NOT LIKE 'netf%' OR "t0"."name" NOT LIKE 'hu%')
+mysql_readable: |+
+  SELECT
+  `theaters`.`id` AS 'ID #',
+  `theaters`.`name` AS 'name'
+  FROM `theaters` `theaters`
+  WHERE
+  (`theaters`.`name` = 'AMC' OR `theaters`.`name` = 'Regal') AND
+  `theaters`.`name` LIKE 'A%' AND
+  `theaters`.`name` LIKE '%m%' AND
+  `theaters`.`active` = FALSE AND
+  (((((`theaters`.`active` = FALSE OR `theaters`.`active` = TRUE) OR
+  `theaters`.`active` = FALSE) OR `theaters`.`active` = TRUE) OR
+  `theaters`.`active` = FALSE) OR
+  `theaters`.`active` = FALSE) AND
+  (((((`theaters`.`inspected` = FALSE OR `theaters`.`inspected` = TRUE) OR
+  `theaters`.`inspected` IS NULL) OR
+  `theaters`.`inspected` = TRUE) OR
+  `theaters`.`inspected` = FALSE) OR
+  `theaters`.`inspected` IS NULL) AND
+  `theaters`.`created_at` <= '2019-03-04' AND
+  `theaters`.`created_at` < '2018-03-04' AND
+  `theaters`.`created_at` >= '2001-03-04' AND
+  `theaters`.`created_at` > '2002-03-04' AND
+  (`theaters`.`name` != 'Netflix' OR `theaters`.`name` != 'Hulu') AND
+  (`theaters`.`name` NOT LIKE '%tfli%' OR `theaters`.`name` NOT LIKE '%ul%') AND
+  (`theaters`.`name` NOT LIKE 'netf%' OR `theaters`.`name` NOT LIKE 'hu%')
+mysql_not_readable: |+
+  SELECT
+  `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1'
+  FROM `theaters` `t0`
+  WHERE
+  (`t0`.`name` = 'AMC' OR `t0`.`name` = 'Regal') AND
+  `t0`.`name` LIKE 'A%' AND
+  `t0`.`name` LIKE '%m%' AND
+  `t0`.`active` = FALSE AND
+  (((((`t0`.`active` = FALSE OR `t0`.`active` = TRUE) OR
+  `t0`.`active` = FALSE) OR `t0`.`active` = TRUE) OR
+  `t0`.`active` = FALSE) OR
+  `t0`.`active` = FALSE) AND
+  (((((`t0`.`inspected` = FALSE OR `t0`.`inspected` = TRUE) OR
+  `t0`.`inspected` IS NULL) OR
+  `t0`.`inspected` = TRUE) OR
+  `t0`.`inspected` = FALSE) OR
+  `t0`.`inspected` IS NULL) AND
+  `t0`.`created_at` <= '2019-03-04' AND
+  `t0`.`created_at` < '2018-03-04' AND
+  `t0`.`created_at` >= '2001-03-04' AND
+  `t0`.`created_at` > '2002-03-04' AND
+  (`t0`.`name` != 'Netflix' OR `t0`.`name` != 'Hulu') AND
+  (`t0`.`name` NOT LIKE '%tfli%' OR `t0`.`name` NOT LIKE '%ul%') AND
+  (`t0`.`name` NOT LIKE 'netf%' OR `t0`.`name` NOT LIKE 'hu%')

--- a/spec/fixtures/active_record_snapshots/one_table_query_with_limit.yaml
+++ b/spec/fixtures/active_record_snapshots/one_table_query_with_limit.yaml
@@ -1,0 +1,30 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+    - key_path: name
+  limit: 123
+sqlite_readable: |+
+  SELECT
+   "theaters"."id" AS 'id',
+  "theaters"."name" AS 'name'
+  FROM "theaters" "theaters"
+  LIMIT 123
+sqlite_not_readable: |+
+  SELECT
+   "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1'
+  FROM "theaters" "t0"
+  LIMIT 123
+mysql_readable: |+
+  SELECT
+   `theaters`.`id` AS 'id',
+  `theaters`.`name` AS 'name'
+  FROM `theaters` `theaters`
+  LIMIT 123
+mysql_not_readable: |+
+  SELECT
+   `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1'
+  FROM `theaters` `t0`
+  LIMIT 123

--- a/spec/fixtures/active_record_snapshots/one_table_query_with_multiple_sorts.yaml
+++ b/spec/fixtures/active_record_snapshots/one_table_query_with_multiple_sorts.yaml
@@ -1,0 +1,33 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+    - key_path: name
+  sorters:
+    - key_path: created_at
+    - key_path: name
+      direction: descending
+sqlite_readable: |+
+  SELECT
+  "theaters"."id" AS 'id',
+  "theaters"."name" AS 'name'
+  FROM "theaters" "theaters"
+  ORDER BY "theaters"."created_at", "theaters"."name" DESC
+sqlite_not_readable: |+
+  SELECT
+  "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1'
+  FROM "theaters" "t0"
+  ORDER BY "t0"."created_at", "t0"."name" DESC
+mysql_readable: |+
+  SELECT
+  `theaters`.`id` AS 'id',
+  `theaters`.`name` AS 'name'
+  FROM `theaters` `theaters`
+  ORDER BY `theaters`.`created_at`, `theaters`.`name` DESC
+mysql_not_readable: |+
+  SELECT
+  `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1'
+  FROM `theaters` `t0`
+  ORDER BY `t0`.`created_at`, `t0`.`name` DESC

--- a/spec/fixtures/active_record_snapshots/two_table_query.yaml
+++ b/spec/fixtures/active_record_snapshots/two_table_query.yaml
@@ -1,0 +1,44 @@
+model_name: Theaters, Members, and Movies
+query:
+  fields:
+    - key_path: id
+    - key_path: name
+    - key_path: members.id
+    - key_path: members.account_number
+  limit: 12
+sqlite_readable: |+
+  SELECT
+   "theaters"."id" AS 'id',
+  "theaters"."name" AS 'name',
+  "members"."id" AS 'members_id',
+  "members"."account_number" AS 'members_account_number'
+  FROM "theaters" "theaters"
+  LEFT OUTER JOIN "members" "members" ON "members"."tid" = "theaters"."id" AND "members"."partition" = "theaters"."partition"
+  LIMIT 12
+sqlite_not_readable: |+
+  SELECT
+   "t0"."id" AS 'c0',
+  "t0"."name" AS 'c1',
+  "t1"."id" AS 'c2',
+  "t1"."account_number" AS 'c3'
+  FROM "theaters" "t0"
+  LEFT OUTER JOIN "members" "t1" ON "t1"."tid" = "t0"."id" AND "t1"."partition" = "t0"."partition"
+  LIMIT 12
+mysql_readable: |+
+  SELECT
+   `theaters`.`id` AS 'id',
+  `theaters`.`name` AS 'name',
+  `members`.`id` AS 'members_id',
+  `members`.`account_number` AS 'members_account_number'
+  FROM `theaters` `theaters`
+  LEFT OUTER JOIN `members` `members` ON `members`.`tid` = `theaters`.`id` AND `members`.`partition` = `theaters`.`partition`
+  LIMIT 12
+mysql_not_readable: |+
+  SELECT
+   `t0`.`id` AS 'c0',
+  `t0`.`name` AS 'c1',
+  `t1`.`id` AS 'c2',
+  `t1`.`account_number` AS 'c3'
+  FROM `theaters` `t0`
+  LEFT OUTER JOIN `members` `t1` ON `t1`.`tid` = `t0`.`id` AND `t1`.`partition` = `t0`.`partition`
+  LIMIT 12

--- a/spec/fixtures/models.yaml
+++ b/spec/fixtures/models.yaml
@@ -1,0 +1,66 @@
+Theaters, Members, and Movies:
+  name: theaters
+  table: theaters
+  columns:
+    - name: active
+      type: boolean
+      nullable: false
+    - name: inspected
+      type: boolean # this one is nullable
+  models:
+    - name: members
+      table: members
+      constraints:
+        - type: reference
+          parent: id
+          name: tid
+        - type: reference
+          parent: partition
+          name: partition
+      models:
+        - name: demos
+          table: demographics
+          constraints:
+            - type: reference
+              parent: id
+              name: member_id
+          models:
+            - name: phone_numbers
+              table: phone_numbers
+              constraints:
+                - type: reference
+                  parent: id
+                  name: demographic_id
+        - name: movies
+          table: movies
+          constraints:
+            - type: reference
+              parent: id
+              name: member_id
+        - name: favorite_comic_movies
+          table: movies
+          constraints:
+            - type: reference
+              parent: id
+              name: member_id
+            - type: static
+              name: genre
+              value: comic
+        - name: favorite_mystery_movies
+          table: movies
+          constraints:
+            - type: reference
+              parent: id
+              name: member_id
+            - type: static
+              name: genre
+              value: mystery
+        - name: favorite_comedy_movies
+          table: movies
+          constraints:
+            - type: reference
+              parent: id
+              name: member_id
+            - type: static
+              name: genre
+              value: comedy

--- a/spec/fixtures/models.yaml
+++ b/spec/fixtures/models.yaml
@@ -1,12 +1,6 @@
 Theaters, Members, and Movies:
   name: theaters
   table: theaters
-  columns:
-    - name: active
-      type: boolean
-      nullable: false
-    - name: inspected
-      type: boolean # this one is nullable
   models:
     - name: members
       table: members

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2018-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'yaml'
+require 'pry'
+
+unless ENV['DISABLE_SIMPLECOV'] == 'true'
+  require 'simplecov'
+  require 'simplecov-console'
+
+  SimpleCov.formatter = SimpleCov::Formatter::Console
+  SimpleCov.start do
+    add_filter %r{\A/spec/}
+  end
+end
+
+require './lib/dbee/providers/active_record_provider'
+
+def fixture_path(*filename)
+  File.join('spec', 'fixtures', filename)
+end
+
+def yaml_fixture(*filename)
+  YAML.safe_load(fixture(*filename))
+end
+
+def fixture(*filename)
+  File.open(fixture_path(*filename), 'r:bom|utf-8').read
+end
+
+def yaml_fixture_files(*directory)
+  Dir[File.join('spec', 'fixtures', *directory, '*.yaml')].map do |filename|
+    [
+      filename,
+      yaml_file_read(filename)
+    ]
+  end.to_h
+end
+
+def yaml_file_read(*filename)
+  YAML.safe_load(file_read(*filename))
+end
+
+def file_read(*filename)
+  File.open(File.join(*filename), 'r:bom|utf-8').read
+end


### PR DESCRIPTION
This PR goes hand-in-hand with [this PR in the Dbee repository](https://github.com/bluemarblepayroll/dbee/pull/1).  This PR contains the initial implementation for how to transform a Dbee::Model and Dbee::Query into a SQL expression using Arel. 

This library does not use ActiveRecord for anything other than connection information.  It actually uses pure Arel for SQL generation, it is just that Arel relies on ActiveRecord for its DBMS connection information / dialect information.  The motivation why this is titled 'dbee-active_record' and not 'dbee-arel' was because even though it is mainly Arel-based, the Arel library exists in the active_record library.